### PR TITLE
fix matrix 1 hover highlighting of stream segments

### DIFF
--- a/src/views/set2/Set2.vue
+++ b/src/views/set2/Set2.vue
@@ -758,7 +758,7 @@
                 seg_class += d.seg_id_nat
                 let key = null;
                 for (key in d.properties.year_count) {
-                  if (d.properties.year_count[key]) {
+                  if (d.properties.year_count[key] > 0) {
                     seg_class += " " + self.timestep_c2p2 + key
                   }
                 }


### PR DESCRIPTION
Addresses issue #15 

* Fix class assignment for river segments so that a class is only added referencing a specific year if the annual count for that year is > 0
  * Change was required b/c of change in how data was structured in updated segment_geojson