### PR TITLE
crossorigins fix for preloading

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -10,5 +10,14 @@ module.exports = {
                 .end()
                 .use('vue-svg-loader')
                 .loader('vue-svg-loader');
+    },
+    configureWebpack: {
+        output: {
+            /*
+                As described on StackOverflow:
+                https://stackoverflow.com/questions/64205612/how-to-correct-preload-key-requests-performance-problem-on-lighthouse-with-vue
+            */
+            crossOriginLoading: 'anonymous'
+        }
     }
 };


### PR DESCRIPTION
Needed one more thing in order to get preloading to actually work (I hope!)

When running the Lighthouse report after the last push to beta, I got this message: 

![image](https://user-images.githubusercontent.com/13220910/98299176-e39c2900-1f7c-11eb-8bd9-964c56f65547.png)
