### PR TITLE
I think I had crossorigins specified in the wrong spot

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -10,14 +10,14 @@ module.exports = {
                 .end()
                 .use('vue-svg-loader')
                 .loader('vue-svg-loader');
-    },
-    configureWebpack: {
-        output: {
-            /*
-                As described on StackOverflow:
-                https://stackoverflow.com/questions/64205612/how-to-correct-preload-key-requests-performance-problem-on-lighthouse-with-vue
-            */
-            crossOriginLoading: 'anonymous'
-        }
+
+        /*
+            As described on StackOverflow:
+            https://stackoverflow.com/questions/64205612/how-to-correct-preload-key-requests-performance-problem-on-lighthouse-with-vue
+            But is in a webpack chain:
+            https://github.com/neutrinojs/webpack-chain#config-output-shorthand-methods
+        */
+        config.output
+            .crossOriginLoading('anonymous');
     }
 };


### PR DESCRIPTION
Switch how the crossorigins config is specified. I thought I had fixed this in #51 but I don't think it was working because we are using `chainWebpack` to setup webpack configs and not `configureWebpack`. I think this fix should do the trick, but there isn't really a way of knowing until it is out on beta.

Another piece of #37.