### PR TITLE
implement d3 transitions to animate histodot plot

### DIFF
--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -273,19 +273,15 @@
             var color_list = ['pink','teal','lightgreen','goldenrod','orangered','cadetblue','orchid','blue','transparent'];
             var color_sel = color_list[data];
             this.model_sel = model_list[data];
-            console.log(this.model_sel);
 
-            this.d3.selectAll(".dot")
-              .transition()
-                .duration(1000)
-                .style('fill', color_sel)
-
+          //move bees to new position
             this.d3.selectAll(".dot")
               .data(this.dodge(this.rmse_monthly, this.radius * 2 + this.padding, this.model_sel))
               .transition()
                 .duration(3000)
                 .attr('cx', d => d.x)
                 .attr('cy', d => this.height - this.marginY -this.padding - this.padding - d.y)
+                .style('fill', color_sel)
 
           },
         // scrollama event handler functions

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -115,11 +115,6 @@
             scroller: scrollama(), 
             step: 0,
             progress: 0,
-            transitionProgress: 0,
-            transitionDirection: 'down',
-            transitionStarted: false,
-            transitionLastTime: null,
-            transitionDuration: 1000,
             model_sel: null,
             
           }
@@ -161,10 +156,12 @@
           },
           callback(data) {
             let rmse_monthly = data[0];
-            var data_set = 'range';
+            var model_list = ['range','range','range','ANN', 'RNN', 'RGCN', 'RGCN_ptrn','RGCN_ptrn','RGCN_ptrn'];
+            var data_set = model_list[this.step];
             this.setChart(rmse_monthly, data_set);
 
           },
+          // resize to keep scroller accurate
           resize () {
             const bounds = this.$refs.figure.getBoundingClientRect()
             this.width = bounds.width

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -157,7 +157,6 @@
                 .onStepProgress(self.handleStepProgress)
                 .onStepExit(self.handleStepExit);
               // 3. setup resize event
-              this.resize();
               window.addEventListener("resize", scroller.resize);
             }
             // kick things off

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -43,7 +43,7 @@
             class="step"
             data-step="2"
           >
-            <p>Using an artificial neural network (ANN) we learn a lot, but there is always room for improvement.</p>
+            <p>ANN</p>
           </div>
         </div>
         <div class="step-container">
@@ -93,8 +93,6 @@
 
 <script>
     import * as d3Base from "d3";
-    import * as d3Force from "d3-force";
-    import {geoScaleBar, geoScaleBottom, geoScaleTop, geoScaleKilometers, geoScaleMiles} from "d3-geo-scale-bar";
     import * as scrollama from 'scrollama';
 
   export default {
@@ -113,6 +111,7 @@
             marginY: 20,
             radius: 5,
             force_sim: null,
+            bees: null,
             x: null,
             scroller: scrollama(), 
             step: 0,
@@ -132,7 +131,7 @@
                 .onStepProgress(this.handleStepProgress)
                 .onStepExit(this.handleStepExit);
 
-          // 3. setup resize event
+          // 3. setup resize event...
           this.resize();
           window.addEventListener("resize", this.resize);
 
@@ -152,13 +151,14 @@
           },
           callback(data) {
             let rmse_monthly = data[0];
-            var model_list = ['range','range','range','ANN', 'RNN', 'RGCN', 'RGCN_ptrn','RGCN_ptrn','RGCN_ptrn'];
+            var model_list = ['ANN','RNN','RGCN','ANN', 'RNN', 'RGCN', 'RGCN_ptrn','RGCN_ptrn','ANN'];
             var data_set = model_list[this.step];
             this.setChart(rmse_monthly, data_set);
 
           },
           // resize to keep scroller accurate
           resize () {
+            const self = this;
             const bounds = this.$refs.figure.getBoundingClientRect()
             this.width = bounds.width
             this.height = bounds.height
@@ -171,13 +171,13 @@
             const self = this;
 
         // append svg
-          var bees = this.d3.select("#bees-container").append("svg")
+          this.bees = this.d3.select("#bees-container").append("svg")
             .attr("viewBox", [0, 0, (this.width+this.marginX+this.marginX), (this.height+this.marginY+this.marginY)].join(' '))
             .attr("width", this.width)
             .attr("height", this.height)
             .attr("class", "bees_dotPlot");
 
-          bees.append("line", 'svg')
+          this.bees.append("line", 'svg')
             .classed("main_line", true)
             .attr("x1", this.marginX)
             .attr("y1", this.height/2)
@@ -186,14 +186,14 @@
             .attr("stroke-width", 1.5)
             .attr("stroke", "#A3A0A6");
             
-          //scales
+          //scale x axis
           this.x = this.d3.scaleLinear()
             .range([this.marginX, this.width - this.marginX])
             .domain([0,7]);
 
           //draw bees
           //use force to push each dot to x position
-          bees.selectAll("dot")
+          this.bees.selectAll("dot")
             .data(data)
           .enter().append("circle").classed('dot', true)
             .attr("r", this.radius)
@@ -223,7 +223,7 @@
             }, 3000);
 
             // add x axis
-            bees.append("g")
+            this.bees.append("g")
               .attr("transform", "translate(0," + this.height + ")")
               .attr("stroke-width", "2px")
               .call(this.d3.axisBottom(self.x));
@@ -234,20 +234,22 @@
           updateChart(data) {
             const self = this;
             // list models in order of transitions, use step index to select
-            var model_list = ['range','range','range','ANN', 'RNN', 'RGCN', 'RGCN_ptrn','RGCN_ptrn','RGCN_ptrn'];
-            var color_list = ['teal','teal','teal','goldenrod','orangered','cadetblue','orchid','blue','transparent'];
+            var model_list = ['ANN','RNN','RGCN','ANN', 'RNN', 'RGCN', 'RGCN_ptrn','RNN','ANN'];
+            var color_list = ['pink','teal','lightgreen','goldenrod','orangered','cadetblue','orchid','blue','transparent'];
             var color_sel = color_list[data];
             var model_sel = model_list[data];
 
-            this.force_sim
+            this.force_sim 
               .force('x', this.d3.forceX(function(d){
                 return self.x(d[model_sel])
-            }).strength(2))
+            }).strength(1))
+            
 
             this.d3.selectAll(".dot")
               .transition()
                 .duration(1000)
                 .style('fill', color_sel)
+                
 
           },
           tick() {
@@ -284,7 +286,7 @@
         },
         // track scroll progress - not returning anything?
         handleStepProgress(response) {
-          console.log(response.progress);
+          //console.log(response.progress);
         }
       }
   }

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -129,9 +129,7 @@
           setScroller() {
             const self = this;
 
-            let promises = [self.d3.csv("data/test.csv"),
-            self.d3.csv(self.publicPath + "data/beeswarm_monthly_rmse_cast.csv")];
-
+            let promises = [self.d3.csv(self.publicPath + "data/beeswarm_monthly_rmse_cast.csv")];
             Promise.all(promises).then(self.callback);
 
             // code to run on load
@@ -140,18 +138,13 @@
             var article = scrolly.querySelector("article");
             var step = article.querySelectorAll(".step");
             var sticky = document.querySelector(".sticky");
-            
 
             // initialize the scrollama
             var scroller = scrollama();
 
             // make scroller
             function init() {
-              // set  padding for step heights 
-              step.forEach(function(step) {
-                var v = 100;
-                step.style.padding = v + "px 0px";
-              });
+
               // 1. setup the scroller and initialize trigger observations
               // 2. bind scrollama event handlers (this can be chained like below)
               scroller
@@ -164,22 +157,16 @@
                 .onStepProgress(self.handleStepProgress)
                 .onStepExit(self.handleStepExit);
               // 3. setup resize event
+              this.resize();
               window.addEventListener("resize", scroller.resize);
             }
             // kick things off
             init();
           },
           callback(data) {
-            let csv_test = data[0];
-            let rmse_monthly = data[1];
-
+            let rmse_monthly = data[0];
             var data_set = 'range';
-
             this.setChart(rmse_monthly, data_set);
-
-            var mappedArray = rmse_monthly.columns;
-            var currentCol = mappedArray[4];
-            //console.log(currentCol);
 
           },
           // draw beeswarm/scatterplot
@@ -217,9 +204,6 @@
             .attr("opacity", .8)
             .attr('cx', function(d){return self.x(d[model]);})
             .attr('cy', function(d){return this.height/2;})
-            .on('click', function(d){
-              self.highlight(d)
-            });
 
           //apply force to push dots towards central position on yaxis
           this.force_sim = this.d3.forceSimulation(data)
@@ -258,13 +242,7 @@
               .call(this.d3.axisBottom(self.x));
 
           },
-          // highlight point on click to track them through movement, don't know how to self select
-          highlight(data) {
-            const self = this;
-            self.d3.selectAll(".dot")
-              .style('stroke','cadetblue')
-              .style('stroke-width',2)
-          },
+
           //update x position on scroll
           updateChart(data) {
             const self = this;
@@ -273,19 +251,16 @@
             var color_list = ['teal','teal','teal','goldenrod','orangered','cadetblue','orchid','blue','transparent'];
             var color_sel = color_list[data];
             var model_sel = model_list[data];
-            //console.log(model_sel);
-
-            //this.setChart(this.rmse_monthly, model_sel);
 
             this.force_sim
               .force('x', this.d3.forceX(function(d){
                 return self.x(d[model_sel])
             }).strength(2))
 
-            /* this.d3.selectAll(".dot")
+            this.d3.selectAll(".dot")
               .transition()
                 .duration(1000)
-                .style('fill', color_sel) */
+                .style('fill', color_sel)
 
           },
           tick() {
@@ -310,9 +285,6 @@
 
           this.updateChart(response.index);
 
-          //let beesFly = [this.flyA, this.flyB, this.flyC, this.flyD];
-          //beesFly[response.index]();
-          
         },
         
         // add remove class on exit

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -9,7 +9,7 @@
       <figure ref="figure" class="sticky">
         <div id="bees-container">
           <div id="progress-container">
-            <p class="progress" />
+          <p class="progress"/>
           </div>
         </div>
       </figure>
@@ -240,10 +240,8 @@
             }
 
             for (const b of this.circles) {
-
               // Remove circles from the queue that can’t intersect the new circle b.
               while (head && head.x < b.x - radius2) head = head.next;
-
               // Choose the minimum non-intersecting tangent.
               if (intersects(b.x, b.y = 0)) {
                 let a = head;
@@ -254,15 +252,12 @@
                   a = a.next;
                 } while (a);
               }
-
               // Add b to the queue.
               b.next = null;
               if (head === null) head = tail = b;
               else tail = tail.next = b;
             }
-
             return this.circles;
-
           },
           
           //update x position on scroll
@@ -282,10 +277,8 @@
                 .attr('cx', d => d.x)
                 .attr('cy', d => this.height - this.marginY -this.padding - this.padding - d.y)
                 .style('fill', color_sel)
-
           },
         // scrollama event handler functions
-
         // add class on enter
         handleStepEnter(response) {
           const self = this;

--- a/src/views/3-Modeling/Modeling.vue
+++ b/src/views/3-Modeling/Modeling.vue
@@ -19,7 +19,7 @@
             class="step"
             data-step="1"
           >
-            <p>Each dot is a monthly RMSE.</p>
+           <!--  <p>Each dot is a monthly RMSE.</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -27,7 +27,7 @@
             class="step"
             data-step="1"
           >
-            <p>RMSE is one way to measure model error/accuracy. RMSE quantifies the distance between predicted and observed values.</p>
+            <!-- <p>RMSE is one way to measure model error/accuracy. RMSE quantifies the distance between predicted and observed values.</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -35,7 +35,7 @@
             class="step"
             data-step="1"
           >
-            <p>Models with RMSE values closer to zero do better at predicting temeprature than models with higher RMSE.</p>
+            <!-- <p>Models with RMSE values closer to zero do better at predicting temeprature than models with higher RMSE.</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -43,7 +43,7 @@
             class="step"
             data-step="2"
           >
-            <p>ANN</p>
+            <!-- <p>ANN</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -51,7 +51,7 @@
             class="step"
             data-step="3"
           >
-            <p>RNN uses time.</p>
+            <!-- <p>RNN uses time.</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -59,7 +59,7 @@
             class="step"
             data-step="4"
           >
-            <p>RGCN adds space.</p>
+            <!-- <p>RGCN adds space.</p> -->
           </div>
         </div>
         <div class="step-container">
@@ -67,14 +67,14 @@
             class="step"
             data-step="5"
           />
-          <p>RGCN + pretraining</p>
+          <!-- <p>RGCN + pretraining</p> -->
         </div>
         <div class="step-container">
           <div
             class="step"
             data-step="6"
           />
-          <p>and that's how we do it!</p>
+         <!--  <p>and that's how we do it!</p> -->
         </div>
         <div class="step-container">
           <div
@@ -208,7 +208,7 @@
              const self = this;
             const radius2 = this.radius ** 3;
 
-            //swap x var to set dodge
+            /* //swap x var to set dodge
             if (model === 'ANN') {
               this.circles = data.map(d => ({x: this.xScale(d['ANN']), data: d})).sort((a,b) => a.x - b.x);
             } 
@@ -220,7 +220,7 @@
             } 
             if (model === 'RGCN_ptrn') {
               this.circles = data.map(d => ({x: this.xScale(d['RGCN_ptrn']), data: d})).sort((a,b) => a.x - b.x);
-            } 
+            }  */
 
             //need to make this line universal so the dataset can be changed on scroll
             this.circles = data.map(d => ({x: this.xScale(d[model]), data: d})).sort((a,b) => a.x - b.x);
@@ -273,7 +273,7 @@
             this.d3.selectAll(".dot")
               .data(this.dodge(this.rmse_monthly, this.radius * 2 + this.padding, this.model_sel))
               .transition()
-                .duration(3000)
+                .duration(1000)
                 .attr('cx', d => d.x)
                 .attr('cy', d => this.height - this.marginY -this.padding - this.padding - d.y)
                 .style('fill', color_sel)
@@ -291,6 +291,7 @@
           self.d3.select("#bees-container p")
           .text(response.index + 1);
 
+          //change chart data w/ transition
           this.updateChart(response.index);
 
         },


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

implement d3 transitions on histodot plot
-----------
Addresses https://github.com/usgs-makerspace/temperature-prediction/issues/47

This is an alternative to the beeswarm + `d3force` with scroll triggers. This implements a stacked dot plot representing RMSEs that uses `d3-transitions` to animate changes between models. This code builds off the core dot plot that was built to make the `dodge` function more flexible to swap out the x-axis data for the transitions. The transitions are still basic, but on scroll, changes the x values based on the scroll `step` index and an array of model option. Took forever to figure out, major progress!

![histodot_transitions](https://user-images.githubusercontent.com/17803537/99263593-0af8be80-27e5-11eb-8cf7-8efeca19da1c.gif)

Colors and model orders are randomly assigned as proof of concept.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial
