### PR TITLE
hide modeling chapter, but allow direct access

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,24 +14,24 @@
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name=”robots” content=”noindex,nofollow”>' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
       <!-- Primary Meta Tags -->
       <title><%= VUE_APP_TIER %><%= VUE_APP_TITLE %></title>
-      <meta name="title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
+      <meta name="title" content="How we Monitor Stream Temperature in the Delaware River Basin">
       <meta name="description" content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
       <!-- Open Graph / Facebook -->
       <meta property="og:type" content="website">
       <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/monitoring">
-      <meta property="og:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
+      <meta property="og:title" content="How we Monitor Stream Temperature in the Delaware River Basin">
       <meta property="og:description" content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
       <meta property="og:image" content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/socialmetacard.jpg">
       <!-- Twitter -->
       <meta property="twitter:card" content="summary_large_image">
       <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/monitoring">
-      <meta property="twitter:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
+      <meta property="twitter:title" content="How we Monitor Stream Temperature in the Delaware River Basin">
       <meta property="twitter:description" content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
       <meta property="twitter:image" content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/social-tag-card-1-1.jpg">
             <meta property="og:type" content="website">
             <meta property="og:url"
               content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/modeling">
-            <meta property="og:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
+            <meta property="og:title" content="How we Monitor Stream Temperature in the Delaware River Basin">
             <meta property="og:description"
               content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
             <meta property="og:image"
@@ -40,7 +40,7 @@
             <meta property="twitter:card" content="summary_large_image">
             <meta property="twitter:url"
               content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/modeling">
-            <meta property="twitter:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
+            <meta property="twitter:title" content="How we Monitor Stream Temperature in the Delaware River Basin">
             <meta property="twitter:description"
               content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
             <meta property="twitter:image"
@@ -48,7 +48,7 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
-        "@type": "WebSite", "name": "How we Monitor and Model Stream Temperature in the Delaware River Basin",
+        "@type": "WebSite", "name": "How we Monitor Stream Temperature in the Delaware River Basin",
         "url": "https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/,
         "about": "The Delaware River Basin covers 13,500 square miles in parts of four states, including New York, New Jersey, Pennsylvania, and Delaware. The Delaware River is rich in history, ecologically diverse, and critical to the regional economy. Water managers in this region have a long history of applying innovative, regional solutions to ensure the long-term sustainability of this resource, which provides drinking water to over 15 million people in the region.",
         "datePublished": "FILL THIS OUT",

--- a/src/components/1-Monitoring/monitoringText.vue
+++ b/src/components/1-Monitoring/monitoringText.vue
@@ -19,7 +19,7 @@
             paragraph11: "Another complexity of predicting temperature dynamics in the basin is that not all streams behave the same way. Features of the landscape can have large effects on water temperature that result in different temperature patterns. Groundwater inputs, reservoirs, and urban areas all have distinct temperature signatures.",
             paragraph12: "If we look at a single year of data, we can see how different stream temperature can be across the basin. Each line in the figure below represents temperature observations from one river reach in the DRB in 2019. In July, mean stream temperature across the basin differed by as much as 26 degrees on a single day. Additionally, you can see drastically different warming and cooling patterns, particularly below reservoirs where stream temperature can deviate from the normal seasonal patterns.",
             paragraph13: "The temperature observations in the basin can be used to inform models that help us predict temperature when or where observations are unavailable. Day ahead temperature forecasts, for example, can help managers decide when to release water from reservoirs. How can we create robust models that account for diverse temperature dynamics and make accurate predictions in places and times where we don't have a lot of information?",
-            paragraph14: "Visit the Model chapter to learn about innovative modeling techniques to predict water temperature."
+            paragraph14: "Learn about innovative modeling techniques to predict water temperature in the upcoming second chapter — How We Model Stream Temperature in the Delaware River Basin — which will be released on June 21."
         }
     }
 </script>

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -2,13 +2,13 @@
   <nav id="nav">
     <div>
       <p>
-        <router-link
+        <!-- router-link
           to="/monitoring"
           @click.native="scrollToTop"
         >Monitor</router-link><router-link
           to="/modeling"
           @click.native="scrollToTop"
-        >Model</router-link>
+        >Model</router-link -->
       </p>
     </div>
   </nav>

--- a/src/components/Nav_title.vue
+++ b/src/components/Nav_title.vue
@@ -5,13 +5,9 @@
         <div class="text-content">
           <br>
           <h1 class="nav-title">
-            How we<router-link
-              to="/monitoring"
-              @click.native="scrollToTop"
-            >Monitor</router-link><span class="dim_text">|</span><router-link
-              to="/modeling"
-              @click.native="scrollToTop"
-            >Model</router-link><br>Stream Temperature in the<br>
+            How we <span
+              class="highlight_word"
+            >Monitor</span><br>Stream Temperature in the<br>
             Delaware River Basin
           </h1>
           <br>
@@ -63,6 +59,10 @@ $dimGray: #9c9c9c;
     background-image: url("../assets/river_title.png");
     background-size: 100% 100%;
   }
+}
+
+.highlight_word {
+  color: $plasmaYellow;
 }
 
 .dim_text {


### PR DESCRIPTION
* Hide modeling chapter but allow for direct access (through `/modeling` extension) so that we can push to prod and test urls.

Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
If no ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial
