### PR TITLE
remove makerspace GTM, add Vizlab GTM

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,13 +21,13 @@
       <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/monitoring">
       <meta property="og:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
       <meta property="og:description" content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
-      <meta property="og:image" content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/socialmetacard.jpg">
+      <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/socialmetacard.jpg">
       <!-- Twitter -->
       <meta property="twitter:card" content="summary_large_image">
       <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/monitoring">
       <meta property="twitter:title" content="How we Monitor and Model Stream Temperature in the Delaware River Basin">
       <meta property="twitter:description" content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
-      <meta property="twitter:image" content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/social-tag-card-1-1.jpg">
+      <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/social-tag-card-1-1.jpg">
             <meta property="og:type" content="website">
             <meta property="og:url"
               content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/modeling">
@@ -35,7 +35,7 @@
             <meta property="og:description"
               content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
             <meta property="og:image"
-              content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/hex.png">
+              content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/hex.png">
             <!-- Twitter -->
             <meta property="twitter:card" content="summary_large_image">
             <meta property="twitter:url"
@@ -44,7 +44,7 @@
             <meta property="twitter:description"
               content="Our understanding of water temperature dynamics in the Delaware River Basin is underpinned by basin-wide monitoring of water temperature. At first glance, it appears that there is a lot of information about stream temperature in the basin. But spatial variability and data gaps make it hard to predict temperatures in all streams.">
             <meta property="twitter:image"
-              content="https://labs-beta.waterdata.usgs.gov/visualizations/temperature-prediction/hex.png">
+              content="https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/hex.png">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <script type='application/ld+json'>
       { "@context": "http://www.schema.org",

--- a/public/index.html
+++ b/public/index.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-MT4BS3B');</script>
-  <!-- End Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MT4BS3B');</script>
+    <!-- End Google Tag Manager -->
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name=”robots” content=”noindex,nofollow”>' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
       <!-- Primary Meta Tags -->
       <title><%= VUE_APP_TIER %><%= VUE_APP_TITLE %></title>
@@ -90,14 +90,10 @@
     </script>
   </head>
   <body>
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-52KNVHL"
-                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-  <!-- VizLab TEST Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MT4BS3B"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MT4BS3B"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong>We're sorry but this page doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
This PR replaces the UA and GA4 tags with the GTM tag and removes the makerspace GTM tag.

The usgs-vizlab GTM container has been configured to point to the existing GA4 account.

Tags on [existing page](https://labs.waterdata.usgs.gov/visualizations/temperature-prediction/index.html#/monitoring): 

![image](https://github.com/DOI-USGS/temperature-prediction/assets/54007288/fb323920-5212-47a8-ac0a-846a1b5897d3)


Tags on updated page (previewed from local host):

![image](https://github.com/DOI-USGS/temperature-prediction/assets/54007288/307cd111-eb30-4897-a3e2-722d689635fe)




Before making a pull request
----------------------------
First . . .
- [X] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [X] Chrome
- [ ] Safari
- [X] Edge
- [X] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)